### PR TITLE
Fix stdlib and Puppet version requirements in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,10 +62,10 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.0.0 < 4.0.0"
+      "version_requirement": ">=3.4.0 < 4.0.0"
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=2.2.1 <5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"}
   ]
 }


### PR DESCRIPTION
Official stdlib docs state that stdlib 2.x is not compatible with Puppet 3.x.
We require Puppet versions 3.4.0 or greater due to #121 