### PR TITLE
Make repo::nodesource::apt compatible with puppetlabs-apt 2.x only

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,9 +1,7 @@
 fixtures:
   repositories:
     "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "apt":
-      repo: "git://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "1.8.0"
+    "apt": "git://github.com/puppetlabs/puppetlabs-apt.git"
     "portage": "git://github.com/gentoo/puppet-portage.git"
     "chocolatey": "git://github.com/chocolatey/puppet-chocolatey.git"
     "epel": "git://github.com/stahnma/puppet-module-epel.git"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Make nodejs::repo::nodesource::apt compatible with puppetlabs-apt 2.x only
 ##2015-05-20 1.0.0
 ###Summary
 

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ it is installed.
 
 This modules uses `puppetlabs-apt` for the management of the NodeSource
 repository. If using an operating system of the Debian-based family, you will
-need to ensure that `puppetlabs-apt` version 1.x is installed.
+need to ensure that `puppetlabs-apt` version 2.x is installed.
 
 If using CentoOS/RHEL 5, you will need to ensure that the `stahnma-epel`
 module is installed.

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -6,18 +6,27 @@ class nodejs::repo::nodesource::apt {
   $pin        = $nodejs::repo::nodesource::pin
   $url_suffix = $nodejs::repo::nodesource::url_suffix
 
+  ensure_packages(['apt-transport-https', 'ca-certificates'])
+
   include ::apt
 
   if ($ensure == 'present') {
     apt::source { 'nodesource':
-      include_src       => $enable_src,
-      key               => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
-      key_source        => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
-      location          => "https://deb.nodesource.com/${url_suffix}",
-      pin               => $pin,
-      release           => $::lsbdistcodename,
-      repos             => 'main',
-      required_packages => 'apt-transport-https ca-certificates',
+      include  => {
+        'src' => $enable_src
+      },
+      key      => {
+        'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
+        'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
+      },
+      location => "https://deb.nodesource.com/${url_suffix}",
+      pin      => $pin,
+      release  => $::lsbdistcodename,
+      repos    => 'main',
+      require  => [
+        Package['apt-transport-https'],
+        Package['ca-certificates'],
+      ],
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -66,6 +66,6 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":">=3.0.0 <5.0.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.1.0 <5.0.0"}
   ]
 }

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -99,9 +99,9 @@ describe 'nodejs', :type => :class do
             })
           end
 
-          it 'the repo apt::source resource should contain include_src = true' do
+          it 'the repo apt::source resource should contain include => { src => true}' do
             should contain_apt__source('nodesource').with({
-              'include_src' => true,
+              'include' => { 'src' => true, },
             })
           end
         end
@@ -113,9 +113,9 @@ describe 'nodejs', :type => :class do
             })
           end
 
-          it 'the repo apt::source resource should contain include_src = false' do
+          it 'the repo apt::source resource should contain include => { src => false}' do
             should contain_apt__source('nodesource').with({
-              'include_src' => false,
+              'include' => { 'src' => false, },
             })
           end
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -28,7 +28,7 @@ RSpec.configure do |c|
     hosts.each do |host|
       copy_module_to(host, :source => proj_root, :module_name => 'nodejs')
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
-      on host, puppet('module install puppetlabs-apt --version 1.8.0'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module install puppetlabs-apt --version 2.0.1'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module install gentoo-portage --version 2.0.1'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module install chocolatey-chocolatey --version 0.5.2'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module install stahnma-epel --version 1.0.0'), { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
An equivalent PR for this has already been started in #129 - this PR just adds some more bits and pieces. It is probably preferred that this get merged AFTER the next release (see #126 )