### PR TITLE
Install NodeJS (and NPM) before any NPM packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,4 +54,6 @@ class nodejs(
     Class['::nodejs::install'] ->
     anchor { '::nodejs::end': }
   }
+  
+  Class['::nodejs'] -> Package <| provider == 'npm' |>
 }


### PR DESCRIPTION
This simple resource ordering statement makes sure that all NPM packages are installed _after_ the whole NodeJS class finishes its work.