### PR TITLE
Added npm package dependency for Archlinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -118,7 +118,7 @@ class nodejs::params {
       $nodejs_dev_package_name   = undef
       $nodejs_package_name       = 'nodejs'
       $npm_package_ensure        = 'present'
-      $npm_package_name          = undef
+      $npm_package_name          = 'npm'
       $npm_path                  = '/usr/bin/npm'
       $repo_class                = undef
     }


### PR DESCRIPTION
Archlinux rather recently moved npm out of their nodejs package and in to a standalone one.