### PR TITLE
fixing amazon default settings

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -98,6 +98,16 @@ class nodejs::params {
         $npm_path                  = '/usr/bin/npm'
         $repo_class                = '::nodejs::repo::nodesource'
       }
+      elsif ($::operatingsystem == 'Amazon') {
+        $manage_package_repo       = true
+        $nodejs_debug_package_name = 'nodejs-debuginfo'
+        $nodejs_dev_package_name   = 'nodejs-devel'
+        $nodejs_package_name       = 'nodejs'
+        $npm_package_ensure        = 'absent'
+        $npm_package_name          = 'npm'
+        $npm_path                  = '/usr/bin/npm'
+        $repo_class                = '::nodejs::repo::nodesource'
+      }
       else {
         fail("The ${module_name} module is not supported on ${::operatingsystem} ${::operatingsystemrelease}.")
       }
@@ -189,6 +199,8 @@ class nodejs::params {
           $repo_class                = undef
         }
         'Amazon': {
+          # this is here only for historical reasons:
+          # old facter and Amazon Linux versions will run into this code path
           $manage_package_repo       = true
           $nodejs_debug_package_name = 'nodejs-debuginfo'
           $nodejs_dev_package_name   = 'nodejs-devel'
@@ -198,6 +210,7 @@ class nodejs::params {
           $npm_path                  = '/usr/bin/npm'
           $repo_class                = '::nodejs::repo::nodesource'
         }
+
         default: {
           fail("The ${module_name} module is not supported on an ${::operatingsystem} distribution.")
         }

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -28,9 +28,15 @@ class nodejs::repo::nodesource {
       }
 
       # Fedora
-      elsif $::operatingsystemrelease =~ /(19)|2[01]/ {
+      elsif $::operatingsystemrelease =~ /(19)|(20)|(21)/ and $::operatingsystem == 'Fedora' {
         $dist_version  = $::operatingsystemrelease
         $name_string   = "Fedora Core ${::operatingsystemrelease}"
+      }
+
+      # newer Amazon Linux releases
+      elsif ($::operatingsystem == 'Amazon') {
+        $dist_version = '7'
+        $name_string  = 'Enterprise Linux 7'
       }
 
       else {

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -36,9 +36,9 @@ describe 'nodejs', :type => :class do
     else
       lsbdistcodename = 'Trusty'
     end
-    
+
     context "when run on #{lsbdistid} release #{operatingsystemrelease}" do
-    
+
       let :facts do
         {
           :lsbdistcodename        => lsbdistcodename,
@@ -63,7 +63,7 @@ describe 'nodejs', :type => :class do
 
       context 'with legacy_debian_symlinks set to false' do
         let (:params) { { :legacy_debian_symlinks => false,} }
-      
+
         it 'the file resource /usr/bin/node should not be in the catalog' do
           is_expected.not_to contain_file('/usr/bin/node')
         end
@@ -184,7 +184,7 @@ describe 'nodejs', :type => :class do
           it 'the nodesource apt sources file should not exist' do
             is_expected.to contain_apt__source('nodesource').with({
               'ensure' => 'absent',
-            }) 
+            })
           end
         end
       end
@@ -344,7 +344,7 @@ describe 'nodejs', :type => :class do
     end
 
     context "when run on #{operatingsystem} release #{operatingsystemrelease}" do
-    
+
       let :facts do
         {
           :operatingsystem           => operatingsystem,
@@ -764,7 +764,7 @@ describe 'nodejs', :type => :class do
       end
     end
   end
-  
+
   context 'when running on Archlinux' do
     let :facts do
       {
@@ -960,7 +960,7 @@ describe 'nodejs', :type => :class do
 
     context 'with npm_package_ensure set to absent' do
       let (:params) { { :npm_package_ensure => 'absent',} }
-  
+
       it 'the npm package should be absent' do
         is_expected.to contain_package('npm').with({
           'ensure' => 'absent',
@@ -968,7 +968,7 @@ describe 'nodejs', :type => :class do
       end
     end
   end
-  
+
   context 'when running on Windows' do
     let :facts do
       { :osfamily        => 'Windows',
@@ -1275,80 +1275,380 @@ describe 'nodejs', :type => :class do
     # nodejs_debug_package_ensure
     context 'with nodejs_debug_package_ensure set to present' do
       let (:params) { { :nodejs_debug_package_ensure => 'present',} }
-  
+
       it 'the nodejs package with debugging symbols should be installed' do
         is_expected.to contain_package('nodejs-debuginfo').with({
           'ensure' => 'present',
         })
       end
     end
-  
+
     context 'with nodejs_debug_package_ensure set to absent' do
       let (:params) { { :nodejs_debug_package_ensure => 'absent',} }
-  
+
       it 'the nodejs package with debugging symbols should not be present' do
         is_expected.to contain_package('nodejs-debuginfo').with({
           'ensure' => 'absent',
         })
       end
     end
-  
+
     # nodejs_dev_package_ensure
     context 'with nodejs_dev_package_ensure set to present' do
       let (:params) { { :nodejs_dev_package_ensure => 'present',} }
-  
+
       it 'the nodejs development package should be installed' do
         is_expected.to contain_package('nodejs-devel').with({
           'ensure' => 'present',
         })
       end
     end
-  
+
     context 'with nodejs_dev_package_ensure set to absent' do
       let (:params) { { :nodejs_dev_package_ensure => 'absent',} }
-  
+
       it 'the nodejs development package should not be present' do
         is_expected.to contain_package('nodejs-devel').with({
           'ensure' => 'absent',
         })
       end
     end
-  
+
     # nodejs_package_ensure
     context 'with nodejs_package_ensure set to present' do
       let (:params) { { :nodejs_package_ensure => 'present',} }
-  
+
       it 'the nodejs package should be present' do
         is_expected.to contain_package('nodejs').with({
           'ensure' => 'present',
         })
       end
     end
-  
+
     context 'with nodejs_package_ensure set to absent' do
       let (:params) { { :nodejs_package_ensure => 'absent',} }
-  
+
       it 'the nodejs package should be absent' do
         is_expected.to contain_package('nodejs').with({
           'ensure' => 'absent',
         })
       end
     end
-  
+
     # npm_package_ensure
     context 'with npm_package_ensure set to present' do
       let (:params) { { :npm_package_ensure => 'present',} }
-  
+
       it 'the npm package should be present' do
         is_expected.to contain_package('npm').with({
           'ensure' => 'present',
         })
       end
     end
-  
+
     context 'with npm_package_ensure set to absent' do
       let (:params) { { :npm_package_ensure => 'absent',} }
-  
+
+      it 'the npm package should be absent' do
+        is_expected.to contain_package('npm').with({
+          'ensure' => 'absent',
+        })
+      end
+    end
+  end
+  context 'when running on Amazon Linux 2015.03' do
+    let :facts do
+        { :osfamily               => 'RedHat',
+          :operatingsystem        => 'Amazon',
+          :operatingsystemrelease => '2015.03',
+        }
+      end
+
+    repo_baseurl        = 'https://rpm.nodesource.com/pub/el/7/$basearch'
+    repo_source_baseurl = 'https://rpm.nodesource.com/pub/el/7/SRPMS'
+    repo_descr          = 'Node.js Packages for Enterprise Linux 7 - $basearch'
+    repo_source_descr   = 'Node.js for Enterprise Linux 7 - $basearch - Source'
+
+    # manage_package_repo
+    context 'with manage_package_repo set to true' do
+      let (:default_params) { { :manage_package_repo => true,} }
+
+      context 'and repo_class set to ::nodejs::repo::nodesource' do
+        let :params do
+          default_params.merge!({
+            :repo_class => 'nodejs::repo::nodesource',
+          })
+        end
+
+        it '::nodejs::repo::nodesource should be in the catalog' do
+          is_expected.to contain_class('nodejs::repo::nodesource')
+        end
+
+        it '::nodejs::repo::nodesource::yum should be in the catalog' do
+          is_expected.to contain_class('nodejs::repo::nodesource::yum')
+        end
+
+        it 'the nodesource and nodesource-source repos should contain the right description and baseurl' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'baseurl' => repo_baseurl,
+            'descr'   => repo_descr,
+          })
+
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'baseurl' => repo_source_baseurl,
+            'descr'   => repo_source_descr,
+          })
+        end
+      end
+
+      context 'and repo_enable_src set to true' do
+        let :params do
+          default_params.merge!({
+            :repo_enable_src => true,
+          })
+        end
+
+        it 'the yumrepo resource nodesource-source should contain enabled = 1' do
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'enabled' => '1',
+          })
+        end
+      end
+
+      context 'and repo_enable_src set to false' do
+        let :params do
+          default_params.merge!({
+            :repo_enable_src => false,
+          })
+        end
+
+        it 'the yumrepo resource should contain enabled = 0' do
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'enabled' => '0',
+          })
+        end
+      end
+
+      context 'and repo_ensure set to present' do
+        let :params do
+          default_params.merge!({
+            :repo_ensure => 'present',
+          })
+        end
+
+        it 'the nodesource yum repo files should exist' do
+          is_expected.to contain_yumrepo('nodesource')
+          is_expected.to contain_yumrepo('nodesource-source')
+        end
+      end
+
+      context 'and repo_ensure set to absent' do
+        let :params do
+          default_params.merge!({
+            :repo_ensure => 'absent',
+          })
+        end
+
+        it 'the nodesource yum repo files should not exist' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'enabled' => 'absent',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'enabled' => 'absent',
+          })
+        end
+      end
+
+      context 'and repo_proxy set to absent' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy => 'absent',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy = absent' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy' => 'absent',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy' => 'absent',
+          })
+        end
+      end
+
+      context 'and repo_proxy set to http://proxy.localdomain.com' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy => 'http://proxy.localdomain.com',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy = http://proxy.localdomain.com' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy' => 'http://proxy.localdomain.com',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy' => 'http://proxy.localdomain.com',
+          })
+        end
+      end
+
+      context 'and repo_proxy_password set to absent' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy_password => 'absent',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy_password = absent' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy_password' => 'absent',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy_password' => 'absent',
+          })
+        end
+      end
+
+      context 'and repo_proxy_password set to password' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy_password => 'password',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy_password = password' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy_password' => 'password',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy_password' => 'password',
+          })
+        end
+      end
+
+      context 'and repo_proxy_username set to absent' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy_username => 'absent',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy_username = absent' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy_username' => 'absent',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy_username' => 'absent',
+          })
+        end
+      end
+
+      context 'and repo_proxy_username set to proxyuser' do
+        let :params do
+          default_params.merge!({
+            :repo_proxy_username => 'proxyuser',
+          })
+        end
+
+        it 'the yumrepo resource should contain proxy_username = proxyuser' do
+          is_expected.to contain_yumrepo('nodesource').with({
+            'proxy_username' => 'proxyuser',
+          })
+          is_expected.to contain_yumrepo('nodesource-source').with({
+            'proxy_username' => 'proxyuser',
+          })
+        end
+      end
+    end
+
+    context 'with manage_package_repo set to false' do
+      let (:params) {{
+        :manage_package_repo => false,
+      }}
+
+      it '::nodejs::repo::nodesource should not be in the catalog' do
+        is_expected.not_to contain_class('::nodejs::repo::nodesource')
+      end
+    end
+
+    # nodejs_debug_package_ensure
+    context 'with nodejs_debug_package_ensure set to present' do
+      let (:params) { { :nodejs_debug_package_ensure => 'present',} }
+
+      it 'the nodejs package with debugging symbols should be installed' do
+        is_expected.to contain_package('nodejs-debuginfo').with({
+          'ensure' => 'present',
+        })
+      end
+    end
+
+    context 'with nodejs_debug_package_ensure set to absent' do
+      let (:params) { { :nodejs_debug_package_ensure => 'absent',} }
+
+      it 'the nodejs package with debugging symbols should not be present' do
+        is_expected.to contain_package('nodejs-debuginfo').with({
+          'ensure' => 'absent',
+        })
+      end
+    end
+
+    # nodejs_dev_package_ensure
+    context 'with nodejs_dev_package_ensure set to present' do
+      let (:params) { { :nodejs_dev_package_ensure => 'present',} }
+
+      it 'the nodejs development package should be installed' do
+        is_expected.to contain_package('nodejs-devel').with({
+          'ensure' => 'present',
+        })
+      end
+    end
+
+    context 'with nodejs_dev_package_ensure set to absent' do
+      let (:params) { { :nodejs_dev_package_ensure => 'absent',} }
+
+      it 'the nodejs development package should not be present' do
+        is_expected.to contain_package('nodejs-devel').with({
+          'ensure' => 'absent',
+        })
+      end
+    end
+
+    # nodejs_package_ensure
+    context 'with nodejs_package_ensure set to present' do
+      let (:params) { { :nodejs_package_ensure => 'present',} }
+
+      it 'the nodejs package should be present' do
+        is_expected.to contain_package('nodejs').with({
+          'ensure' => 'present',
+        })
+      end
+    end
+
+    context 'with nodejs_package_ensure set to absent' do
+      let (:params) { { :nodejs_package_ensure => 'absent',} }
+
+      it 'the nodejs package should be absent' do
+        is_expected.to contain_package('nodejs').with({
+          'ensure' => 'absent',
+        })
+      end
+    end
+
+    # npm_package_ensure
+    context 'with npm_package_ensure set to present' do
+      let (:params) { { :npm_package_ensure => 'present',} }
+
+      it 'the npm package should be present' do
+        is_expected.to contain_package('npm').with({
+          'ensure' => 'present',
+        })
+      end
+    end
+
+    context 'with npm_package_ensure set to absent' do
+      let (:params) { { :npm_package_ensure => 'absent',} }
+
       it 'the npm package should be absent' do
         is_expected.to contain_package('npm').with({
           'ensure' => 'absent',


### PR DESCRIPTION
Amazon LInux (at least on Version 2015.03) reports its own osfamily as RedHat therefore the old code causes the manifest to fail.
This PR fixes the detection.