### PR TITLE
Fix failing provider RSpec test when running on docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 ---
-sudo: true
+sudo: false
 language: ruby
 bundler_args: --without system_tests
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"

--- a/spec/unit/puppet/provider/package/npm_spec.rb
+++ b/spec/unit/puppet/provider/package/npm_spec.rb
@@ -60,6 +60,7 @@ describe Puppet::Type.type(:package).provider(:npm) do
 
     it "should log and return no packages if JSON isn't output" do
       @provider.class.expects(:execute).with(['/usr/local/bin/npm', 'list', '--json', '--global'], anything).returns("failure!")
+      Process::Status.any_instance.expects(:success?).returns(true)
       Puppet.expects(:debug).with(regexp_matches(/npm list.*failure!/))
       expect(@provider.class.instances).to eq([])
     end


### PR DESCRIPTION
This hack mocks an exit success so that the test does not fail when
run on docker.