### PR TITLE
Exodusftw qualify global config var

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ nodejs::npm { 'remove all express packages':
 
 ### nodejs::npm::global_config_entry
 
-nodejs::npm::global_config_entry can be used to set global npm configuration settings.
+nodejs::npm::global_config_entry can be used to set/remove global npm configuration settings.
 
 Examples:
 

--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -8,12 +8,31 @@ define nodejs::npm::global_config_entry (
 
   validate_re($ensure, '^(present|absent)$', "${module_name}::npm::global_config_entry : Ensure parameter must be present or absent")
 
-  $command = $ensure ? {
-    'absent' => "config delete ${config_setting}",
-    default  => "config set ${config_setting} ${value} --global",
+  case $ensure {
+    'absent': {
+      $command        = "config delete ${config_setting} --global"
+      $onlyif_command = $::osfamily ? {
+        'Windows' => "CMD /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
+        default   => "${npm_path} get --global | /bin/grep -e \"^${config_setting}\"",
+      }
+    }
+    default: {
+      $command        = "config set ${config_setting} ${value} --global"
+      $onlyif_command = $::osfamily ? {
+        'Windows' => "CMD /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
+        default   => "/usr/bin/test \"$(${npm_path} get ${config_setting} --global | /usr/bin/tr -d '\n')\" != \"${value}\"",
+      }
+    }
   }
 
+  #Determine exec provider
+  $provider = $::osfamily ? {
+    'Windows' => 'windows',
+    default   => 'shell',
+  }
   exec { "npm_config ${ensure} ${title}":
-    command => "${npm_path} ${command}",
+    command  => "${npm_path} ${command}",
+    provider => $provider,
+    onlyif   => $onlyif_command,
   }
 }

--- a/manifests/npm/global_config_entry.pp
+++ b/manifests/npm/global_config_entry.pp
@@ -2,6 +2,7 @@
 define nodejs::npm::global_config_entry (
   $ensure         = 'present',
   $config_setting = $title,
+  $cmd_exe_path   = $::nodejs::cmd_exe_path,
   $npm_path       = $::nodejs::params::npm_path,
   $value          = undef,
 ) {
@@ -12,14 +13,14 @@ define nodejs::npm::global_config_entry (
     'absent': {
       $command        = "config delete ${config_setting} --global"
       $onlyif_command = $::osfamily ? {
-        'Windows' => "CMD /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
+        'Windows' => "${cmd_exe_path} /C ${npm_path} get --global| FINDSTR /B \"${config_setting}\"",
         default   => "${npm_path} get --global | /bin/grep -e \"^${config_setting}\"",
       }
     }
     default: {
       $command        = "config set ${config_setting} ${value} --global"
       $onlyif_command = $::osfamily ? {
-        'Windows' => "CMD /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
+        'Windows' => "${cmd_exe_path} /C FOR /F %i IN ('${npm_path} get ${config_setting} --global') DO IF \"%i\" NEQ \"${value}\" ( EXIT 0 ) ELSE ( EXIT 1 )",
         default   => "/usr/bin/test \"$(${npm_path} get ${config_setting} --global | /usr/bin/tr -d '\n')\" != \"${value}\"",
       }
     }

--- a/spec/defines/global_config_entry_spec.rb
+++ b/spec/defines/global_config_entry_spec.rb
@@ -46,7 +46,7 @@ describe 'nodejs::npm::global_config_entry', :type => :define do
 
       it 'npm config delete color should be executed' do
         is_expected.to contain_exec('npm_config absent color').with({
-          'command' => '/usr/bin/npm config delete color',
+          'command' => '/usr/bin/npm config delete color --global',
         })
       end
     end


### PR DESCRIPTION
modified behavior of global_config_entry type by including "onlyif" attribute on exec to ensure config variables are only added/removed when set to absent or whenever present value doesn't match desired value