### PR TITLE
Allowed home environment variable to be set

### DIFF
--- a/manifests/npm.pp
+++ b/manifests/npm.pp
@@ -8,6 +8,7 @@ define nodejs::npm (
   $package           = $title,
   $source            = 'registry',
   $uninstall_options = [],
+  $home_dir          = '/root',
   $user              = undef,
 ) {
 
@@ -66,11 +67,12 @@ define nodejs::npm (
     Nodejs::Npm::Global_config_entry<| title == 'proxy' |> -> Exec["npm_install_${name}"]
 
     exec { "npm_${npm_command}_${name}":
-      command => "${npm_path} ${npm_command} ${package_string} ${options}",
-      unless  => $install_check,
-      user    => $user,
-      cwd     => $target,
-      require => Class['nodejs'],
+      command     => "${npm_path} ${npm_command} ${package_string} ${options}",
+      unless      => $install_check,
+      user        => $user,
+      cwd         => $target,
+      environment => "HOME=${home_dir}",
+      require     => Class['nodejs'],
     }
   }
 }

--- a/spec/defines/nodejs_npm_spec.rb
+++ b/spec/defines/nodejs_npm_spec.rb
@@ -47,19 +47,25 @@ describe 'nodejs::npm', :type => :define do
       it 'the command should be npm install express' do
         should contain_exec('npm_install_express').with({
           'command' => '/usr/bin/npm install express ',
-         })
+        })
       end
 
       it 'the install_check should grep for /home/npm/packages/node_modules/express' do
         should contain_exec('npm_install_express').with({
           'unless'  => "/usr/bin/npm ls --long --parseable | grep \"/home/npm/packages/node_modules/express\"",
-         })
+        })
       end
 
       it 'the exec directory should be /home/npm/packages' do
         should contain_exec('npm_install_express').with({
           'cwd'  => '/home/npm/packages',
-         })
+        })
+      end
+
+      it 'the environment variable HOME should be /root' do
+        is_expected.to contain_exec('npm_install_express').with({
+          'environment'  => 'HOME=/root',
+        })
       end
     end
 


### PR DESCRIPTION
This was fixed in the package provider, but never fixed in the exec the nodejs::npm class was utilizing for installations:

Heres a bit of background:

Node-gyp expects either HOME or USERPROFILE to be defined in the environment. If it is not set, installation will fail.

```
Error: node-gyp requires that the user's home directory is specified in either of the environmental variables HOME or USERPROFILE
```