### PR TITLE
Added puppetlab-apt dependency

### DIFF
--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -27,6 +27,7 @@ class nodejs::repo::nodesource::apt {
         Package['apt-transport-https'],
         Package['ca-certificates'],
       ],
+      notify   => Exec['apt_update'],
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -67,6 +67,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">=4.1.0 <5.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">=2.1.0 <3.0.0"},
     {"name":"treydock/gpg_key","version_requirement":">=0.0.3 <1.0.0"}
   ]
 }


### PR DESCRIPTION
README says

This modules uses puppetlabs-apt for the management of the NodeSource repository. If using an operating system of the Debian-based family, you will need to ensure that puppetlabs-apt version 2.x is installed.

Related to h#172 and probably #171