### PR TITLE
Make repo_url_suffix to be usable for RH/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,25 @@ User for the proxy used by the repository, if required.
 #### `repo_url_suffix`
 
 This module defaults to installing the latest NodeSource 0.10.x release on
-Debian platforms. If you wish to install a 0.12.x release you will need to
-set this parameter to `node_0.12` instead.
+Debian and RedHat (i.e. RHEL/CentOS/Fedora/Amazon Linux) platforms. If you wish to install a
+0.12.x release or greater, you will need to set this parameter accordingly.
+Accepted values are as follows:
+
+* Debian
+  * 0.10 (default)
+  * 0.12
+  * 4.x
+  * 5.x
+* Ubuntu
+  * 0.10 (default, **Not** available for Ubuntu 15.10)
+  * 0.12 (**Not** available for Ubuntu 15.10)
+  * 4.x (**Not** available for Ubuntu 10, 11 and 13)
+  * 5.x (**Not** available for Ubuntu 10, 11 and 13)
+* RedHat (RHEL/CentOS/Fedora/Amazon Linux)
+  * 0.10 (default, **Not** available for Fedora 23)
+  * 0.12 (**Not** available for Fedora 23)
+  * 4.x (**Only** available for RedHat/CentOS/Amazon Linux 7 and Fedora 21/22/23)
+  * 5.x (**Only** available for RedHat/CentOS/Amazon Linux 7 and Fedora 21/22/23)
 
 #### `use_flags`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class nodejs::params {
   $repo_proxy                  = 'absent'
   $repo_proxy_password         = 'absent'
   $repo_proxy_username         = 'absent'
-  $repo_url_suffix             = 'node_0.10'
+  $repo_url_suffix             = '0.10'
   $use_flags                   = ['npm', 'snapshot']
 
   # The full path to cmd.exe is required on Windows. The system32 fact is only

--- a/manifests/repo/nodesource.pp
+++ b/manifests/repo/nodesource.pp
@@ -50,11 +50,11 @@ class nodejs::repo::nodesource {
 
       # nodesource repo
       $descr   = "Node.js Packages for ${name_string} - \$basearch"
-      $baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/\$basearch"
+      $baseurl = "https://rpm.nodesource.com/pub_${url_suffix}/${dist_type}/${dist_version}/\$basearch"
 
       # nodesource-source repo
       $source_descr   = "Node.js for ${name_string} - \$basearch - Source"
-      $source_baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/SRPMS"
+      $source_baseurl = "https://rpm.nodesource.com/pub_${url_suffix}/${dist_type}/${dist_version}/SRPMS"
 
       class { '::nodejs::repo::nodesource::yum': }
       contain '::nodejs::repo::nodesource::yum'
@@ -82,11 +82,11 @@ class nodejs::repo::nodesource {
 
         # nodesource repo
         $descr   = "Node.js Packages for ${name_string} - \$basearch"
-        $baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/\$basearch"
+        $baseurl = "https://rpm.nodesource.com/pub_${url_suffix}/${dist_type}/${dist_version}/\$basearch"
 
         # nodesource-source repo
         $source_descr   = "Node.js for ${name_string} - \$basearch - Source"
-        $source_baseurl = "https://rpm.nodesource.com/pub/${dist_type}/${dist_version}/SRPMS"
+        $source_baseurl = "https://rpm.nodesource.com/pub_${url_suffix}/${dist_type}/${dist_version}/SRPMS"
 
         class { '::nodejs::repo::nodesource::yum': }
         contain '::nodejs::repo::nodesource::yum'

--- a/manifests/repo/nodesource/apt.pp
+++ b/manifests/repo/nodesource/apt.pp
@@ -19,7 +19,7 @@ class nodejs::repo::nodesource::apt {
         'id'     => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
         'source' => 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key',
       },
-      location => "https://deb.nodesource.com/${url_suffix}",
+      location => "https://deb.nodesource.com/node_${url_suffix}",
       pin      => $pin,
       release  => $::lsbdistcodename,
       repos    => 'main',

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -148,17 +148,23 @@ describe 'nodejs', :type => :class do
           end
         end
 
-        context 'and repo_url_suffix set to node_0.12' do
+        context 'and repo_url_suffix set to 0.12' do
           let :params do
             default_params.merge!({
-              :repo_url_suffix => 'node_0.12',
+              :repo_url_suffix => '0.12',
             })
           end
 
-          it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
-            is_expected.to contain_apt__source('nodesource').with({
-              'location' => 'https://deb.nodesource.com/node_0.12'
-            })
+          if operatingsystemrelease == '10.04'
+            it 'NodeJS 0.12 package not provided for Ubuntu Lucid' do
+              expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '0.12' is not set correctly for Ubuntu 10.04. See README./)
+            end
+          else
+            it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
+              is_expected.to contain_apt__source('nodesource').with({
+                'location' => 'https://deb.nodesource.com/node_0.12'
+              })
+            end
           end
         end
 
@@ -331,14 +337,14 @@ describe 'nodejs', :type => :class do
 
     if operatingsystemrelease =~ /^[5-7]\.(\d+)/
       operatingsystem     = 'CentOS'
-      repo_baseurl        = "https://rpm.nodesource.com/pub/el/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub/el/#{operatingsystemmajrelease}/SRPMS"
+      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/el/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/el/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Enterprise Linux #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Enterprise Linux #{operatingsystemmajrelease} - \$basearch - Source"
     else
       operatingsystem     = 'Fedora'
-      repo_baseurl        = "https://rpm.nodesource.com/pub/fc/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub/fc/#{operatingsystemmajrelease}/SRPMS"
+      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/fc/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/fc/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Fedora Core #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Fedora Core #{operatingsystemmajrelease} - \$basearch - Source"
     end
@@ -1064,8 +1070,8 @@ describe 'nodejs', :type => :class do
       }
     end
 
-    repo_baseurl        = 'https://rpm.nodesource.com/pub/el/7/$basearch'
-    repo_source_baseurl = 'https://rpm.nodesource.com/pub/el/7/SRPMS'
+    repo_baseurl        = 'https://rpm.nodesource.com/pub_0.10/el/7/$basearch'
+    repo_source_baseurl = 'https://rpm.nodesource.com/pub_0.10/el/7/SRPMS'
     repo_descr          = 'Node.js Packages for Enterprise Linux 7 - $basearch'
     repo_source_descr   = 'Node.js for Enterprise Linux 7 - $basearch - Source'
 
@@ -1364,8 +1370,8 @@ describe 'nodejs', :type => :class do
         }
       end
 
-    repo_baseurl        = 'https://rpm.nodesource.com/pub/el/7/$basearch'
-    repo_source_baseurl = 'https://rpm.nodesource.com/pub/el/7/SRPMS'
+    repo_baseurl        = 'https://rpm.nodesource.com/pub_0.10/el/7/$basearch'
+    repo_source_baseurl = 'https://rpm.nodesource.com/pub_0.10/el/7/SRPMS'
     repo_descr          = 'Node.js Packages for Enterprise Linux 7 - $basearch'
     repo_source_descr   = 'Node.js for Enterprise Linux 7 - $basearch - Source'
 


### PR DESCRIPTION
Hi,

This PR is intended to make the repo_url_suffix variable usable for RPM repos so that you can install NodeJS version 0.10 and above on RedHat based systems. The default value has been changed from "node_0.10" to "0.10". The suffix is then appended to repo URLs (node_**suffix** for Debian and pub_**suffix** for RedHat).

I also added some checks regarding the repo_url_suffix variable. There're still missing repos for some version of RedHat or Ubuntu on Nodesource, so I found it relevant to add these checks. Let me know if you find this addition useful or a pain to maintain  ;) - I'll exclude this part from the PR in this case.

I've successfully tested this on Debian/Ubuntu and RedHat/CentOS.