### PR TITLE
Fix repo_url_suffix regex validation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,7 @@ class nodejs(
 
   # Validate repo_url_suffix. Not every versions of NodeJS are available
   # for all distros at Nodesource. We need to check that.
-  if $repo_class == '::nodejs::repo::nodesource' {
+  if ($manage_package_repo) and ($repo_class == '::nodejs::repo::nodesource') {
     $suffix_error_msg = "Var \$repo_url_suffix with value '${repo_url_suffix}' is not set correctly for ${::operatingsystem} ${::operatingsystemrelease}. See README."
     case $::osfamily {
       'Debian': {
@@ -38,14 +38,14 @@ class nodejs(
           validate_re($repo_url_suffix, '^0\.1[02]$', $suffix_error_msg)
         }
         elsif $::operatingsystemrelease =~ /^1[245]\.04$/ {
-          validate_re($repo_url_suffix, '^0\.1[02]|[45]\.x$', $suffix_error_msg)
+          validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
         }
         elsif $::operatingsystemrelease =~ /^15\.10$/ {
           validate_re($repo_url_suffix, '^[45]\.x$', $suffix_error_msg)
         }
         # All NodeJS versions are available for Debian 7 and 8
         else {
-          validate_re($repo_url_suffix, '^0\.1[02]|[45]\.x$', $suffix_error_msg)
+          validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
         }
       }
       'RedHat': {
@@ -55,15 +55,15 @@ class nodejs(
           validate_re($repo_url_suffix, '^0\.1[02]$', $suffix_error_msg)
         }
         elsif $::operatingsystemrelease =~ /^7\.(\d+)/ {
-          validate_re($repo_url_suffix, '^0\.1[02]|[45]\.x$', $suffix_error_msg)
+          validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
         }
         # Fedora
         elsif $::operatingsystem == 'Fedora' {
           if $::operatingsystemrelease =~ /^19|20$/ {
-            validate_re($repo_url_suffix, '^0\.1[02]|4\.x$', $suffix_error_msg)
+            validate_re($repo_url_suffix, '^(0\.1[02]|4\.x)$', $suffix_error_msg)
           }
           elsif $::operatingsystemrelease =~ /^21|22$/ {
-            validate_re($repo_url_suffix, '^0\.1[02]|[45]\.x$', $suffix_error_msg)
+            validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
           }
           elsif $::operatingsystemrelease == '23' {
             validate_re($repo_url_suffix, '^[45]\.x$', $suffix_error_msg)
@@ -74,7 +74,7 @@ class nodejs(
         if $::operatingsystem == 'Amazon' {
           # Based on RedHat 7
           if $::operatingsystemrelease =~ /^201[4-9]\./ {
-            validate_re($repo_url_suffix, '^0\.1[02]|[45]\.x$', $suffix_error_msg)
+            validate_re($repo_url_suffix, '^(0\.1[02]|[45]\.x)$', $suffix_error_msg)
           }
           # Based on Redhat 6
           else {

--- a/spec/classes/nodejs_spec.rb
+++ b/spec/classes/nodejs_spec.rb
@@ -157,7 +157,7 @@ describe 'nodejs', :type => :class do
 
           if operatingsystemrelease == '10.04'
             it 'NodeJS 0.12 package not provided for Ubuntu Lucid' do
-              expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '0.12' is not set correctly for Ubuntu 10.04. See README./)
+              expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '0\.12' is not set correctly for Ubuntu 10\.04\. See README\./)
             end
           else
             it 'the repo apt::source resource should contain location = https://deb.nodesource.com/node_0.12' do
@@ -165,6 +165,19 @@ describe 'nodejs', :type => :class do
                 'location' => 'https://deb.nodesource.com/node_0.12'
               })
             end
+          end
+        end
+
+        # repo_url_suffix regex checks validation
+        context 'and repo_url_suffix set to 0.1O.0' do
+          let :params do
+            default_params.merge!({
+              :repo_url_suffix => '0.10.0',
+            })
+          end
+
+          it 'repo_url_suffix regex checks should fail' do
+            expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '0\.10\.0' is not set correctly for \w+ \d+(\.\d+)+\. See README\./)
           end
         end
 
@@ -337,14 +350,16 @@ describe 'nodejs', :type => :class do
 
     if operatingsystemrelease =~ /^[5-7]\.(\d+)/
       operatingsystem     = 'CentOS'
-      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/el/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/el/#{operatingsystemmajrelease}/SRPMS"
+      dist_type           = 'el'
+      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Enterprise Linux #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Enterprise Linux #{operatingsystemmajrelease} - \$basearch - Source"
     else
       operatingsystem     = 'Fedora'
-      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/fc/#{operatingsystemmajrelease}/\$basearch"
-      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/fc/#{operatingsystemmajrelease}/SRPMS"
+      dist_type           = 'fc'
+      repo_baseurl        = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
+      repo_source_baseurl = "https://rpm.nodesource.com/pub_0.10/#{dist_type}/#{operatingsystemmajrelease}/SRPMS"
       repo_descr          = "Node.js Packages for Fedora Core #{operatingsystemmajrelease} - \$basearch"
       repo_source_descr   = "Node.js for Fedora Core #{operatingsystemmajrelease} - \$basearch - Source"
     end
@@ -389,6 +404,39 @@ describe 'nodejs', :type => :class do
               'baseurl' => repo_source_baseurl,
               'descr'   => repo_source_descr,
             })
+          end
+        end
+
+        context 'and repo_url_suffix set to 5.x' do
+          let :params do
+            default_params.merge!({
+              :repo_url_suffix => '5.x',
+            })
+          end
+
+          if operatingsystemrelease =~ /^([56]\.\d+|20)$/
+            it 'NodeJS 5.x package not provided for Centos 5/6 and Fedora 20' do
+              expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '5\.x' is not set correctly for \w+ \d+(\.\d+)*\. See README\./)
+            end
+          else
+            it "the yum nodesource repo resource should contain baseurl = https://rpm.nodesource.com/pub_5.x/#{dist_type}/#{operatingsystemmajrelease}/\$basearch" do
+              is_expected.to contain_yumrepo('nodesource').with({
+                'baseurl' => "https://rpm.nodesource.com/pub_5.x/#{dist_type}/#{operatingsystemmajrelease}/\$basearch"
+              })
+            end
+          end
+        end
+
+        # repo_url_suffix regex checks validation
+        context 'and repo_url_suffix set to 0.1O.0' do
+          let :params do
+            default_params.merge!({
+              :repo_url_suffix => '0.10.0',
+            })
+          end
+
+          it 'repo_url_suffix regex checks should fail' do
+            expect { catalogue }.to raise_error(Puppet::Error, /Var \$repo_url_suffix with value '0\.10\.0' is not set correctly for \w+ \d+(\.\d+)*\. See README\./)
           end
         end
 


### PR DESCRIPTION
Hi guys,

This PR is linked to #174 
I made a small mistake in regex checks for repo_url_suffix. This could lead to **$repo_url_suffix** not raising an error when wrongly set to **0.10.0** for example (the **0.10** is matched only so validate_re is not failing). This PR fixes that.

Sorry for that ;)