### PR TITLE
Update the puppet version requirement since tests and implementations…

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 < 4.0.0"
+      "version_requirement": ">=3.4.0 <5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
… are successful against Puppet 4 on Ubuntu 14.04 agent (puppetserver-2.1.1/puppet-agent-1.2.1)

Fixes https://github.com/puppet-community/puppet-nodejs/issues/175