### PR TITLE
Bump minimum Puppet version to 3.7.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 <5.0.0"
+      "version_requirement": ">=3.7.0 <5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Puppet issue PUP-1597 appears to be the cause of #149 . This issue was fixed in 3.7.0.